### PR TITLE
feat: Add virtual chassis import option for stacked switches

### DIFF
--- a/netbox_catalyst_center/__init__.py
+++ b/netbox_catalyst_center/__init__.py
@@ -37,6 +37,14 @@ class CatalystCenterConfig(PluginConfig):
         "timeout": 30,  # API timeout in seconds
         "cache_timeout": 60,  # Cache results for 60 seconds
         "verify_ssl": False,  # Skip SSL verification for self-signed certs
+        # Virtual Chassis: Import stacks as virtual chassis with separate devices per member
+        # When enabled, stacks are imported as:
+        # - One device per stack member (hostname.1, hostname.2, etc.)
+        # - A Virtual Chassis linking all members
+        # - Physical interfaces assigned to members based on slot (e.g., 2/0/1 -> member 2)
+        # - Logical interfaces (VLANs, Loopbacks, Port-channels) assigned to master
+        # When disabled (default), stacks are imported as single devices
+        "enable_virtual_chassis": False,
         # Device types to show tab for and lookup method
         # Format: list of dicts with manufacturer (regex), device_type (regex, optional), lookup method
         # lookup: "hostname" = network device lookup, "mac" = wireless client lookup


### PR DESCRIPTION
Add enable_virtual_chassis configuration option that allows importing
stacked switches as Virtual Chassis with separate devices per member:

- New config option: enable_virtual_chassis (default: False)
- When enabled, stacks import as hostname.1, hostname.2, etc.
- Physical interfaces assigned to members based on slot number
  (e.g., GigabitEthernet2/0/1 -> member 2)
- Logical interfaces (VLANs, Loopbacks, Port-channels) stay on master
- Management IP and primary data stays on master device

Closes #2